### PR TITLE
Derive trade risk budget from equity metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ pytest -q
 - Computes ATR and volatility forecasts
 - Chooses effective SL/TP based on regime and confidence
 - Computes R, R:R, and position sizing guidance
+- Budgets risk off account equity with configurable 0.5–1% guard rails and reports the applied dollars
 - Emits per-position analysis dict and portfolio report
 
 ... existing code ...
@@ -147,6 +148,7 @@ pytest -q
 - Incorporates probability of hitting TP before SL and adapts the effective TP multiplier
 
 Key configuration keys:
+- [risk] min_equity_risk_frac / max_equity_risk_frac for equity-based risk guard rails
 - [vol] horizon_hours
 - [stops] breakeven_after_R, atr_trail_mult_initial, atr_trail_mult_late
 - [prob] prob_alpha, prob_target, m_min, m_max, m_step

--- a/changes.MD
+++ b/changes.MD
@@ -17,10 +17,13 @@ Got it. Here’s a tight, actionable plan to make your system less conservative 
 Add a new section so you can tune without code changes:
 
 [risk]
-base_target_pct = 0.025         # was 0.02; start 2.5%
+# base_target_pct still feeds dynamic scaling but equity guard rails keep risk modest
+base_target_pct = 0.025         # pre-clamp target before equity limits
 min_target_pct = 0.015
 max_target_pct = 0.040
 use_dynamic = true
+min_equity_risk_frac = 0.005    # clamp per-trade risk to ≥0.5% of equity
+max_equity_risk_frac = 0.010    # and ≤1% unless config overrides
 
 [stops]
 # baseline multipliers by leverage *before* regime multipliers


### PR DESCRIPTION
### **User description**
## Summary
- derive each trade's risk budget from available account equity with configurable guard rails and balance awareness
- surface the equity-derived risk budget and applied fraction in the per-position analysis payload
- document the new equity clamp defaults in the README and configuration guidance

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'adaptive_stop_loss')*

------
https://chatgpt.com/codex/tasks/task_e_68cee93c6fa08324980114db34635739


___

### **PR Type**
Enhancement


___

### **Description**
- Derive trade risk budget from account equity metrics

- Add configurable equity-based risk guard rails (0.5%-1%)

- Surface equity metrics in position analysis payload

- Document new equity clamp defaults in README


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Account Metrics"] --> B["Resolve Equity"]
  B --> C["Apply Risk Fraction"]
  C --> D["Clamp to Guard Rails"]
  D --> E["Calculate Risk Budget"]
  E --> F["Position Analysis"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>position_risk_manager.py</strong><dd><code>Implement equity-based risk budgeting system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

market_analysis/position_risk_manager.py

<ul><li>Add <code>_resolve_account_equity()</code> method to derive equity from multiple <br>metrics<br> <li> Implement equity-based risk budgeting with configurable floor/cap <br>limits<br> <li> Replace notional-based risk calculation with equity-derived budget<br> <li> Surface equity metrics and risk fraction in analysis payload</ul>


</details>


  </td>
  <td><a href="https://github.com/PedroDnT/bybit_position_manager/pull/4/files#diff-7da586ada2bdc8465fb082f1b9c82694176af416380379f368eeadfdc6ece4d1">+61/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document equity risk budgeting feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Document new equity-based risk budgeting feature<br> <li> Add configuration guidance for equity guard rails</ul>


</details>


  </td>
  <td><a href="https://github.com/PedroDnT/bybit_position_manager/pull/4/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>changes.MD</strong><dd><code>Add equity risk configuration parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

changes.MD

<ul><li>Add new risk configuration parameters for equity guard rails<br> <li> Document min/max equity risk fraction settings</ul>


</details>


  </td>
  <td><a href="https://github.com/PedroDnT/bybit_position_manager/pull/4/files#diff-15b32c23d65f077421cc3bd9f005a669478603a7820118c8a0d71b3824fcb478">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

