### PR TITLE
feat: enforce configurable liquidation buffer cushion

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ pytest -q
 - Computes R, R:R, and position sizing guidance
 - Emits per-position analysis dict and portfolio report
 
+#### Liquidation buffer guardrail
+
+- The `[risk].liquidation_buffer_multiple` setting controls how far the liquidation price must sit beyond the recommended stop.
+- By default the guardrail requires the liquidation price to be at least **2.0 ×** the stop distance (roughly twice the ATR-based cushion).
+- Increase the multiple to demand more breathing room during high leverage or volatile regimes; lower it if exchange margin rules already provide a generous cushion.
+- Reports surface both the observed buffer ratio and the configured threshold so thin cushions are easy to spot.
+
 ... existing code ...
 
 ### 🧠 Advanced Risk Logic Explained

--- a/market_analysis/reporting.py
+++ b/market_analysis/reporting.py
@@ -163,10 +163,18 @@ def generate_report(
             f"    💰 Current Risk: ${analysis.get('current_dollar_risk', 0):.2f} (for current size: {analysis['position_size']:.2f})"
         )
         if analysis.get("liquidation_buffer_safe") is not None:
+            ratio = analysis.get("liquidation_buffer_ratio")
+            threshold = analysis.get("liquidation_buffer_threshold")
+            detail = ""
+            if ratio is not None and threshold is not None:
+                detail = f" (buffer {ratio:.2f}× vs ≥ {threshold:.2f}×)"
+            elif threshold is not None:
+                detail = f" (requires ≥ {threshold:.2f}× cushion)"
+
             if analysis["liquidation_buffer_safe"]:
-                report.append(f"    ✅ Safe from liquidation")
+                report.append(f"    ✅ Safe from liquidation{detail}")
             else:
-                report.append(f"    ⚠️  TOO CLOSE TO LIQUIDATION!")
+                report.append(f"    ⚠️  TOO CLOSE TO LIQUIDATION!{detail}")
         report.append(
             f"  TAKE PROFIT: ${analysis['take_profit']:.6f} ({analysis['tp_pct']:.2f}% from entry)"
         )

--- a/tests/test_position_risk_manager.py
+++ b/tests/test_position_risk_manager.py
@@ -1,0 +1,53 @@
+import pytest
+
+from market_analysis.position_risk_manager import evaluate_liquidation_buffer
+
+
+def test_liquidation_buffer_safe_with_deep_cushion():
+    """A wide liquidation cushion relative to the stop distance is marked safe."""
+    result = evaluate_liquidation_buffer(
+        stop_distance=10.0,
+        liquidation_distance=30.0,
+        threshold_ratio=2.0,
+    )
+
+    assert result["safe"] is True
+    assert pytest.approx(result["ratio"]) == 3.0
+    assert pytest.approx(result["required_distance"]) == 20.0
+    assert pytest.approx(result["threshold_ratio"]) == 2.0
+
+
+def test_liquidation_buffer_flags_risk_when_stop_widens():
+    """Wider stops (e.g. from higher volatility) can erode the liquidation cushion."""
+    baseline = evaluate_liquidation_buffer(
+        stop_distance=10.0,
+        liquidation_distance=30.0,
+        threshold_ratio=2.0,
+    )
+    widened = evaluate_liquidation_buffer(
+        stop_distance=20.0,
+        liquidation_distance=30.0,
+        threshold_ratio=2.0,
+    )
+
+    assert baseline["safe"] is True
+    assert widened["safe"] is False
+    assert pytest.approx(widened["ratio"]) == 1.5
+
+
+def test_liquidation_buffer_tracks_volatility_driven_threshold():
+    """Higher buffer multiples (e.g. during extreme volatility) tighten requirements."""
+    relaxed = evaluate_liquidation_buffer(
+        stop_distance=12.0,
+        liquidation_distance=30.0,
+        threshold_ratio=2.0,
+    )
+    strict = evaluate_liquidation_buffer(
+        stop_distance=12.0,
+        liquidation_distance=30.0,
+        threshold_ratio=3.0,
+    )
+
+    assert relaxed["safe"] is True
+    assert strict["safe"] is False
+    assert pytest.approx(strict["threshold_ratio"]) == 3.0


### PR DESCRIPTION
### **User description**
## Summary
- replace the fixed liquidation guardrail with a configurable stop-distance multiple and expose the helper for reuse
- surface the observed ratio, threshold, and required distance in the risk analysis/reporting output and document the new tuning knob
- add regression tests covering safe/unsafe transitions as stop distance or volatility-driven thresholds change

## Testing
- pytest tests/test_position_risk_manager.py
- pytest tests *(fails: pre-existing calibration validation metrics and structural lint checks)*

------
https://chatgpt.com/codex/tasks/task_e_68cee93fa5c0832495c0f5848f2232df


___

### **PR Type**
Enhancement


___

### **Description**
- Replace fixed liquidation guardrail with configurable buffer multiple

- Add `evaluate_liquidation_buffer` helper function for reusable risk assessment

- Surface buffer ratio, threshold, and required distance in risk reporting

- Add comprehensive regression tests for safe/unsafe liquidation transitions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fixed Liquidation Check"] --> B["Configurable Buffer Multiple"]
  B --> C["evaluate_liquidation_buffer()"]
  C --> D["Enhanced Risk Reporting"]
  C --> E["Regression Tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>position_risk_manager.py</strong><dd><code>Implement configurable liquidation buffer system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

market_analysis/position_risk_manager.py

<ul><li>Add <code>evaluate_liquidation_buffer</code> function with configurable threshold <br>logic<br> <li> Replace hardcoded liquidation checks with configurable buffer multiple<br> <li> Initialize <code>liquidation_buffer_multiple</code> from settings with fallback to <br>2.0<br> <li> Enhanced risk analysis output with buffer metrics</ul>


</details>


  </td>
  <td><a href="https://github.com/PedroDnT/bybit_position_manager/pull/6/files#diff-7da586ada2bdc8465fb082f1b9c82694176af416380379f368eeadfdc6ece4d1">+91/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reporting.py</strong><dd><code>Enhanced liquidation buffer reporting details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

market_analysis/reporting.py

<ul><li>Add detailed buffer ratio and threshold information to liquidation <br>reports<br> <li> Display buffer metrics in safety/warning messages<br> <li> Show required cushion multiplier in reporting output</ul>


</details>


  </td>
  <td><a href="https://github.com/PedroDnT/bybit_position_manager/pull/6/files#diff-c29bbfe0fc1f5d81198cc6950ff1befa5a576ad439b62e0cf106b4ad595869c5">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_position_risk_manager.py</strong><dd><code>Comprehensive liquidation buffer regression tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_position_risk_manager.py

<ul><li>Add test for safe liquidation buffer with deep cushion<br> <li> Test risk flagging when stop distance widens<br> <li> Test threshold tracking with volatility-driven changes</ul>


</details>


  </td>
  <td><a href="https://github.com/PedroDnT/bybit_position_manager/pull/6/files#diff-b0af8174c20bc15f26457e70c043be11eaefcdfe54b02a390f73b10cebd5ced1">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document liquidation buffer configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Document new <code>liquidation_buffer_multiple</code> configuration setting<br> <li> Explain default 2.0x buffer requirement and tuning guidance<br> <li> Describe enhanced reporting of buffer ratios and thresholds</ul>


</details>


  </td>
  <td><a href="https://github.com/PedroDnT/bybit_position_manager/pull/6/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

