### PR TITLE
Add drawdown-aware portfolio risk throttle

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Once installed, you can run the analysis using the new command-line tool:
 risk-manager
 ```
 
+The command prints a per-position table that surfaces the GARCH-driven stop loss, take profit, and trailing stop guidance alongside risk budget, sizing multipliers, and the volatility model that produced the levels.
+
 To run in real-time monitoring mode:
 
 ```bash
@@ -132,6 +134,7 @@ pytest -q
 - Chooses effective SL/TP based on regime and confidence
 - Computes R, R:R, and position sizing guidance
 - Budgets risk off account equity with configurable 0.5–1% guard rails and reports the applied dollars
+- Enforces a drawdown-aware portfolio risk cap that scales planned losses when they exceed a configurable fraction of equity
 - Emits per-position analysis dict and portfolio report
 
 #### Liquidation buffer guardrail
@@ -156,6 +159,7 @@ pytest -q
 
 Key configuration keys:
 - [risk] min_equity_risk_frac / max_equity_risk_frac for equity-based risk guard rails
+- [portfolio] max_portfolio_risk_frac / min_portfolio_risk_frac / drawdown_multipliers for the equity-level risk throttle
 - [vol] horizon_hours
 - [stops] breakeven_after_R, atr_trail_mult_initial, atr_trail_mult_late
 - [prob] prob_alpha, prob_target, m_min, m_max, m_step

--- a/changes.MD
+++ b/changes.MD
@@ -58,6 +58,12 @@ horizon_hours = 4                # keep consistent with your timeframe
 corr_lookback_days = 60
 corr_threshold = 0.7
 cluster_risk_cap_pct = 0.5       # max fraction of total risk per highly-correlated cluster
+max_portfolio_risk_frac = 0.04   # cap planned portfolio loss to 4% of equity by default
+min_portfolio_risk_frac = 0.01   # never tighten below 1% of equity without explicit override
+drawdown_multipliers = [         # ratchet cap lower after drawdowns
+    { pnl_frac = -0.02, multiplier = 0.75 },
+    { pnl_frac = -0.04, multiplier = 0.50 },
+]
 
 
 ⸻

--- a/tests/test_position_risk_manager.py
+++ b/tests/test_position_risk_manager.py
@@ -1,6 +1,13 @@
+import pandas as pd
 import pytest
+from unittest.mock import Mock
 
-from market_analysis.position_risk_manager import evaluate_liquidation_buffer
+from market_analysis import position_risk_manager as prm
+from market_analysis.position_risk_manager import (
+    PositionRiskManager,
+    evaluate_liquidation_buffer,
+)
+
 
 def test_liquidation_buffer_safe_with_deep_cushion():
     """A wide liquidation cushion relative to the stop distance is marked safe."""
@@ -50,13 +57,6 @@ def test_liquidation_buffer_tracks_volatility_driven_threshold():
     assert relaxed["safe"] is True
     assert strict["safe"] is False
     assert pytest.approx(strict["threshold_ratio"]) == 3.0
-=======
-import pandas as pd
-import pytest
-from unittest.mock import Mock
-
-from market_analysis import position_risk_manager as prm
-from market_analysis.position_risk_manager import PositionRiskManager
 
 
 @pytest.fixture
@@ -113,8 +113,19 @@ def configured_manager(monkeypatch):
         "stops": {
             "use_state_anchored": False,
         },
+        "portfolio": {},
     }
     manager.exchange = Mock()
+    manager.account_metrics = {
+        "total_equity": 100000.0,
+        "total_wallet_balance": 100000.0,
+        "available_balance": 50000.0,
+        "todays_realized_pnl": 0.0,
+        "todays_total_pnl": 0.0,
+    }
+    manager.liquidation_buffer_multiple = 2.0
+    manager.positions = []
+    manager.risk_analysis = {}
 
     return manager
 
@@ -156,3 +167,93 @@ def test_risk_overage_within_bounds_keeps_normal_health(configured_manager):
     assert analysis["risk_size_overage_triggered"] is False
     assert analysis["position_health"] == "NORMAL"
     assert analysis["action_required"] == "Set SL/TP as recommended"
+
+
+def test_portfolio_throttle_scales_risk_when_cap_is_breached(configured_manager):
+    manager = configured_manager
+    manager.cfg["portfolio"] = {
+        "max_portfolio_risk_frac": 0.04,
+        "min_portfolio_risk_frac": 0.01,
+        "drawdown_multipliers": [{"pnl_frac": -0.02, "multiplier": 0.5}],
+    }
+    manager.account_metrics["total_equity"] = 50_000.0
+    manager.account_metrics["todays_realized_pnl"] = -3_000.0
+    manager.account_metrics["todays_total_pnl"] = -3_000.0
+
+    first = base_position(size=1.0)
+    second = base_position(size=1.0)
+    second["symbol"] = "ETHUSDT"
+    manager.positions = [first, second]
+
+    template_analysis = {
+        "dollar_risk": 4_000.0,
+        "dollar_reward": 8_000.0,
+        "optimal_position_size": 2.0,
+        "target_risk_dollars": 4_000.0,
+    }
+
+    manager.risk_analysis = {
+        "BTCUSDT": template_analysis.copy(),
+        "ETHUSDT": template_analysis.copy(),
+    }
+
+    manager._apply_portfolio_risk_throttle()
+
+    scale = 0.125  # Risk budget reduced to $1,000 on $50k equity with 6% drawdown
+    for symbol in ("BTCUSDT", "ETHUSDT"):
+        analysis = manager.risk_analysis[symbol]
+        assert analysis["dollar_risk"] == pytest.approx(500.0)
+        assert analysis["dollar_reward"] == pytest.approx(1_000.0)
+        assert analysis["target_risk_dollars"] == pytest.approx(500.0)
+        assert analysis["optimal_position_size"] == pytest.approx(0.25)
+        assert analysis["portfolio_throttle_scale"] == pytest.approx(scale)
+
+    throttle_meta = manager.risk_analysis["portfolio_throttle"]
+    assert throttle_meta["throttle_applied"] is True
+    assert throttle_meta["risk_cap_dollars"] == pytest.approx(1_000.0)
+    assert throttle_meta["drawdown_fraction"] == pytest.approx(-0.06)
+    assert throttle_meta["post_scale_total_risk"] == pytest.approx(1_000.0)
+
+
+def test_portfolio_throttle_leaves_risk_unchanged_when_within_budget(configured_manager):
+    manager = configured_manager
+    manager.cfg["portfolio"] = {
+        "max_portfolio_risk_frac": 0.04,
+        "min_portfolio_risk_frac": 0.01,
+        "drawdown_multipliers": [{"pnl_frac": -0.02, "multiplier": 0.5}],
+    }
+    manager.account_metrics["total_equity"] = 50_000.0
+    manager.account_metrics["todays_realized_pnl"] = 1_000.0
+    manager.account_metrics["todays_total_pnl"] = 1_000.0
+
+    first = base_position(size=1.0)
+    second = base_position(size=1.0)
+    second["symbol"] = "ETHUSDT"
+    manager.positions = [first, second]
+
+    manager.risk_analysis = {
+        "BTCUSDT": {
+            "dollar_risk": 400.0,
+            "dollar_reward": 800.0,
+            "optimal_position_size": 2.0,
+            "target_risk_dollars": 400.0,
+        },
+        "ETHUSDT": {
+            "dollar_risk": 400.0,
+            "dollar_reward": 800.0,
+            "optimal_position_size": 2.0,
+            "target_risk_dollars": 400.0,
+        },
+    }
+
+    manager._apply_portfolio_risk_throttle()
+
+    for symbol in ("BTCUSDT", "ETHUSDT"):
+        analysis = manager.risk_analysis[symbol]
+        assert analysis["dollar_risk"] == pytest.approx(400.0)
+        assert "portfolio_throttle_scale" not in analysis
+
+    throttle_meta = manager.risk_analysis["portfolio_throttle"]
+    assert throttle_meta["throttle_applied"] is False
+    assert throttle_meta["risk_cap_dollars"] == pytest.approx(2_000.0)
+    assert throttle_meta["scale"] == pytest.approx(1.0)


### PR DESCRIPTION
### **User description**
## Summary
- add a portfolio-level risk throttle that scales exposure when aggregate planned loss breaches an equity-based cap
- surface the throttle status, cap and utilization in the portfolio report and document the new controls
- add regression tests covering throttle scaling behaviour and fixture updates for equity-based sizing
- extend the CLI summary table to print the GARCH-based stop-loss, take-profit, trailing stop, and volatility model metadata so traders see the advanced levels immediately

## Testing
- pytest tests/test_position_risk_manager.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cee6331cdc8324b93fde3c70533744


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced CLI table with trailing stops and volatility method columns

- Added portfolio-level risk throttle that scales exposure based on equity drawdown

- Implemented drawdown-aware risk budgeting with configurable multipliers

- Added comprehensive test coverage for throttle scaling behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI Table"] --> B["Enhanced Display"]
  C["Portfolio Risk"] --> D["Throttle Logic"]
  D --> E["Drawdown Scaling"]
  E --> F["Position Sizing"]
  G["Risk Analysis"] --> H["Portfolio Metrics"]
  H --> I["Report Generation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__main__.py</strong><dd><code>Enhanced CLI table with advanced risk metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

market_analysis/__main__.py

<ul><li>Enhanced CLI table with trailing stop and volatility method columns<br> <li> Added robust number formatting functions for table display<br> <li> Expanded table width to accommodate new risk management fields</ul>


</details>


  </td>
  <td><a href="https://github.com/PedroDnT/bybit_position_manager/pull/8/files#diff-bf66f407729cf2e1c4f1d53fee95ead8c240f5cade5a0b709fb99bc32ac32a0c">+57/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>position_risk_manager.py</strong><dd><code>Implemented drawdown-aware portfolio risk throttle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

market_analysis/position_risk_manager.py

<ul><li>Added <code>_apply_portfolio_risk_throttle()</code> method for equity-based risk <br>scaling<br> <li> Implemented drawdown-aware risk budgeting with configurable <br>multipliers<br> <li> Restructured portfolio risk application order and correlation cap <br>integration<br> <li> Added portfolio throttle metadata tracking and position scaling logic</ul>


</details>


  </td>
  <td><a href="https://github.com/PedroDnT/bybit_position_manager/pull/8/files#diff-7da586ada2bdc8465fb082f1b9c82694176af416380379f368eeadfdc6ece4d1">+141/-2</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reporting.py</strong><dd><code>Enhanced reporting with throttle metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

market_analysis/reporting.py

<ul><li>Added portfolio throttle metrics to portfolio calculations<br> <li> Enhanced report generation with risk cap, utilization, and drawdown <br>display<br> <li> Added throttle status warnings and scaling information</ul>


</details>


  </td>
  <td><a href="https://github.com/PedroDnT/bybit_position_manager/pull/8/files#diff-c29bbfe0fc1f5d81198cc6950ff1befa5a576ad439b62e0cf106b4ad595869c5">+59/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_position_risk_manager.py</strong><dd><code>Added portfolio throttle test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_position_risk_manager.py

<ul><li>Added comprehensive test coverage for portfolio throttle scaling <br>behavior<br> <li> Created test fixtures with mock account metrics and equity data<br> <li> Added tests for both throttle activation and normal operation <br>scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/PedroDnT/bybit_position_manager/pull/8/files#diff-b0af8174c20bc15f26457e70c043be11eaefcdfe54b02a390f73b10cebd5ced1">+109/-8</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Updated documentation for new features</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated CLI description to mention GARCH-driven levels display<br> <li> Added documentation for drawdown-aware portfolio risk cap feature</ul>


</details>


  </td>
  <td><a href="https://github.com/PedroDnT/bybit_position_manager/pull/8/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>changes.MD</strong><dd><code>Added throttle configuration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

changes.MD

<ul><li>Added portfolio configuration section with risk throttle parameters<br> <li> Documented <code>max_portfolio_risk_frac</code>, <code>min_portfolio_risk_frac</code>, and <br><code>drawdown_multipliers</code></ul>


</details>


  </td>
  <td><a href="https://github.com/PedroDnT/bybit_position_manager/pull/8/files#diff-15b32c23d65f077421cc3bd9f005a669478603a7820118c8a0d71b3824fcb478">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

